### PR TITLE
allow user to expand long crucible values

### DIFF
--- a/src/views/Widget/TabContent/Panes/Operate/CrucibleCard.tsx
+++ b/src/views/Widget/TabContent/Panes/Operate/CrucibleCard.tsx
@@ -1,0 +1,190 @@
+import React, { Dispatch, SetStateAction, useState } from "react";
+import { decimalCount } from "../../../utils";
+import { Button, ButtonGroup } from "@chakra-ui/button";
+import { Badge, Box, Flex, HStack, Text } from "@chakra-ui/layout";
+import { FaLock } from "react-icons/fa";
+import { Tooltip } from "@chakra-ui/tooltip";
+import { useColorModeValue } from "@chakra-ui/color-mode";
+
+interface CrucibleCardProps {
+  crucible: {
+    id: string;
+    balance: string;
+    lockedBalance: string;
+  };
+  setModalOperation: Dispatch<SetStateAction<"withdraw" | "unstake" | "send" | "increaseStake">>;
+  setSelectedCrucible: (crucible: any) => void;
+  setModalIsOpen: (open: boolean) => void;
+}
+const CrucibleCard: React.FC<CrucibleCardProps> = (props) => {
+  const { crucible, setModalOperation, setSelectedCrucible, setModalIsOpen } = props;
+  const cruciblesCardBg = useColorModeValue("white", "gray.600");
+  const [expandBalance, setExpandBalance] = useState(false);
+  const [expandLock, setExpandLock] = useState(false);
+
+  const expandBalanceNumber = () => {
+    setExpandBalance(!expandBalance);
+    setExpandLock(false);
+  };
+
+  const expandLockNumber = () => {
+    setExpandLock(!expandLock);
+    setExpandBalance(false);
+  };
+
+  const isBalanceTrunc = decimalCount(crucible?.balance) > 3;
+  const isLockTrunc = decimalCount(crucible?.lockedBalance) > 3;
+
+  return (
+    <Box
+      key={crucible.id}
+      p={4}
+      mb={6}
+      bg={cruciblesCardBg}
+      boxShadow="md"
+      borderWidth={1}
+      borderRadius="lg"
+      alignItems="center"
+      justifyContent="space-between"
+      flexDirection={"column"}
+    >
+      <Box mb={4}>
+        <Text as="div" fontSize="lg" textAlign={["center", "center", "left"]}>
+          <Flex justifyContent="space-between" flexDirection="column">
+            <Flex justifyContent="space-between">
+              <Tooltip
+                label="click me for full number"
+                placement="top"
+                hasArrow={true}
+                isDisabled={expandBalance || !isBalanceTrunc}
+              >
+                <Box
+                  onClick={isBalanceTrunc ? expandBalanceNumber : undefined}
+                  _hover={isBalanceTrunc ? { cursor: "pointer" } : undefined}
+                >
+                  <strong>Balance: </strong>
+                  {!expandBalance ? (
+                    <>
+                      {`${parseFloat(Number(crucible?.balance).toFixed(3))}`}
+                      {isBalanceTrunc && "..."}
+                    </>
+                  ) : (
+                    crucible?.balance
+                  )}
+                </Box>
+              </Tooltip>
+              <Tooltip
+                label="click me for full number"
+                placement="top"
+                hasArrow={true}
+                isDisabled={expandLock || !isLockTrunc}
+              >
+                <Badge
+                  py={1}
+                  px={2}
+                  borderRadius="xl"
+                  fontSize=".7em"
+                  onClick={isLockTrunc ? expandLockNumber : undefined}
+                  _hover={isLockTrunc ? { cursor: "pointer" } : undefined}
+                >
+                  <HStack>
+                    <Box>
+                      {!expandLock ? (
+                        <>
+                          {parseFloat(Number(crucible?.lockedBalance).toFixed(3))}
+                          {isLockTrunc && "..."}
+                        </>
+                      ) : (
+                        crucible?.lockedBalance
+                      )}
+                    </Box>
+                    <FaLock />
+                  </HStack>
+                </Badge>
+              </Tooltip>
+            </Flex>
+            <Flex fontSize="sm" color="gray.400" textAlign="left" verticalAlign="top" marginTop="8px">
+              <label style={{ alignSelf: "flex-start" }}>ID: </label>
+              <span style={{ wordWrap: "break-word", width: "100%", paddingLeft: "4px", paddingRight: "16px" }}>
+                {crucible["id"]}
+              </span>
+            </Flex>
+          </Flex>
+        </Text>
+      </Box>
+      <ButtonGroup isAttached variant="outline" mb={[4, 4, 0]} width="100%">
+        {/*
+              <Button
+                isFullWidth
+                color="white"
+                borderWidth={1}
+                borderColor={cruciblesCardBg}
+                background="brand.400"
+                fontSize={{ base: "sm", sm: "md" }}
+                _focus={{ boxShadow: "none" }}
+                _hover={{ background: "brand.400" }}
+                onClick={() => {
+                  setModalOperation("increaseStake");
+                  setSelectedCrucible(crucible["id"]);
+                  setModalIsOpen(true);
+                }}
+              >
+                Increase stake
+              </Button>
+              */}
+        <Button
+          isFullWidth
+          color="white"
+          borderWidth={1}
+          borderColor={cruciblesCardBg}
+          background="brand.400"
+          _focus={{ boxShadow: "none" }}
+          _hover={{ background: "brand.400" }}
+          onClick={() => {
+            setModalOperation("unstake");
+            setSelectedCrucible(crucible["id"]);
+            setModalIsOpen(true);
+          }}
+        >
+          Unstake
+        </Button>
+        <Button
+          isFullWidth
+          color="white"
+          borderWidth={1}
+          borderColor={cruciblesCardBg}
+          background="brand.400"
+          fontSize={{ base: "sm", sm: "md" }}
+          _focus={{ boxShadow: "none" }}
+          _hover={{ background: "brand.400" }}
+          onClick={() => {
+            setModalOperation("withdraw");
+            setSelectedCrucible(crucible["id"]);
+            setModalIsOpen(true);
+          }}
+        >
+          Withdraw
+        </Button>
+        <Button
+          isFullWidth
+          color="white"
+          borderWidth={1}
+          borderColor={cruciblesCardBg}
+          background="brand.400"
+          fontSize={{ base: "sm", sm: "md" }}
+          _focus={{ boxShadow: "none" }}
+          _hover={{ background: "brand.400" }}
+          onClick={() => {
+            setModalOperation("send");
+            setSelectedCrucible(crucible["id"]);
+            setModalIsOpen(true);
+          }}
+        >
+          Send
+        </Button>
+      </ButtonGroup>
+    </Box>
+  );
+};
+
+export default CrucibleCard;

--- a/src/views/Widget/TabContent/Panes/Operate/CrucibleCard.tsx
+++ b/src/views/Widget/TabContent/Panes/Operate/CrucibleCard.tsx
@@ -53,7 +53,7 @@ const CrucibleCard: React.FC<CrucibleCardProps> = (props) => {
           <Flex justifyContent="space-between" flexDirection="column">
             <Flex justifyContent="space-between">
               <Tooltip
-                label="click me for full number"
+                label="View total balance"
                 placement="top"
                 hasArrow={true}
                 isDisabled={expandBalance || !isBalanceTrunc}
@@ -74,7 +74,7 @@ const CrucibleCard: React.FC<CrucibleCardProps> = (props) => {
                 </Box>
               </Tooltip>
               <Tooltip
-                label="click me for full number"
+                label="View staked balance"
                 placement="top"
                 hasArrow={true}
                 isDisabled={expandLock || !isLockTrunc}

--- a/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
+++ b/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { toMaxDecimalsRound } from "../../../utils";
+import { toMaxDecimalsRound, decimalCount } from "../../../utils";
 import Web3Context from "../../../../../Web3Context";
 import { getOwnedCrucibles } from "../../../../../contracts/getOwnedCrucibles";
 import { unstakeAndClaim } from "../../../../../contracts/unstakeAndClaim";
@@ -19,8 +19,8 @@ import {
 } from "@chakra-ui/modal";
 import { Input } from "@chakra-ui/input";
 import { FormControl, FormLabel } from "@chakra-ui/form-control";
-import { useColorModeValue } from "@chakra-ui/color-mode";
 import { mintAndLock } from "../../../../../contracts/alchemist";
+import CrucibleCard from "./CrucibleCard";
 
 interface OperatePaneProps {
   handleInputChange?: (form: { [key: string]: string | number }) => void;
@@ -108,8 +108,6 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
     setModalIsOpen(false);
   };
 
-  const cruciblesCardBg = useColorModeValue("white", "gray.600");
-
   const sendModal = (
     <Modal isOpen onClose={() => setModalIsOpen(false)}>
       <ModalOverlay />
@@ -158,7 +156,7 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
           <Modal isOpen onClose={() => setModalIsOpen(false)}>
             <ModalOverlay />
             <ModalContent>
-            <ModalHeader>
+              <ModalHeader>
                 {modalOperation === "withdraw"
                   ? "Withdraw"
                   : modalOperation === "unstake"
@@ -223,113 +221,12 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
 
       {crucibles.map((crucible) => {
         return (
-          <Box
-            key={crucible.id}
-            p={4}
-            mb={6}
-            bg={cruciblesCardBg}
-            boxShadow="md"
-            borderWidth={1}
-            borderRadius="lg"
-            alignItems="center"
-            justifyContent="space-between"
-            flexDirection={"column"}
-          >
-            <Box mb={4}>
-              <Text as="div" fontSize="lg" textAlign={["center", "center", "left"]}>
-                <Flex justifyContent="space-between" flexDirection="column">
-                  <Flex justifyContent="space-between">
-                    <Box>
-                      <strong>Balance:</strong> {`${crucible["balance"]}`}
-                    </Box>
-                    <Badge py={1} px={2} borderRadius="xl" fontSize=".7em">
-                      <HStack>
-                        <Box>{crucible["lockedBalance"]}</Box>
-                        <FaLock />
-                      </HStack>
-                    </Badge>
-                  </Flex>
-                  <Flex fontSize="sm" color="gray.400" textAlign="left" verticalAlign="top" marginTop="8px">
-                    <label style={{ alignSelf: "flex-start" }}>ID: </label>
-                    <span style={{ wordWrap: "break-word", width: "100%", paddingLeft: "4px", paddingRight: "16px" }}>
-                      {crucible["id"]}
-                    </span>
-                  </Flex>
-                </Flex>
-              </Text>
-            </Box>
-            <ButtonGroup isAttached variant="outline" mb={[4, 4, 0]} width="100%">
-              {/*
-              <Button
-                isFullWidth
-                color="white"
-                borderWidth={1}
-                borderColor={cruciblesCardBg}
-                background="brand.400"
-                fontSize={{ base: "sm", sm: "md" }}
-                _focus={{ boxShadow: "none" }}
-                _hover={{ background: "brand.400" }}
-                onClick={() => {
-                  setModalOperation("increaseStake");
-                  setSelectedCrucible(crucible["id"]);
-                  setModalIsOpen(true);
-                }}
-              >
-                Increase stake
-              </Button>
-              */}
-              <Button
-                isFullWidth
-                color="white"
-                borderWidth={1}
-                borderColor={cruciblesCardBg}
-                background="brand.400"
-                _focus={{ boxShadow: "none" }}
-                _hover={{ background: "brand.400" }}
-                onClick={() => {
-                  setModalOperation("unstake");
-                  setSelectedCrucible(crucible["id"]);
-                  setModalIsOpen(true);
-                }}
-              >
-                Unstake
-              </Button>
-              <Button
-                isFullWidth
-                color="white"
-                borderWidth={1}
-                borderColor={cruciblesCardBg}
-                background="brand.400"
-                fontSize={{ base: "sm", sm: "md" }}
-                _focus={{ boxShadow: "none" }}
-                _hover={{ background: "brand.400" }}
-                onClick={() => {
-                  setModalOperation("withdraw");
-                  setSelectedCrucible(crucible["id"]);
-                  setModalIsOpen(true);
-                }}
-              >
-                Withdraw
-              </Button>
-              <Button
-                isFullWidth
-                color="white"
-                borderWidth={1}
-                borderColor={cruciblesCardBg}
-                background="brand.400"
-                fontSize={{ base: "sm", sm: "md" }}
-                _focus={{ boxShadow: "none" }}
-                _hover={{ background: "brand.400" }}
-                onClick={() => {
-                  setModalOperation("send");
-                  setSelectedCrucible(crucible["id"]);
-                  setModalIsOpen(true);
-                }}
-              >
-                Send
-              </Button>
-            </ButtonGroup>
-          </Box>
+          <CrucibleCard
+            crucible={crucible}
+            setModalOperation={setModalOperation}
+            setModalIsOpen={setModalIsOpen}
+            setSelectedCrucible={setSelectedCrucible}
+          />
         );
       })}
       {isConnected ? (

--- a/src/views/Widget/utils.ts
+++ b/src/views/Widget/utils.ts
@@ -44,3 +44,12 @@ export function addDecimalsToUint(amount: string, tokenDecimals: number) {
 export function sha256(buffer: Buffer) {
   return createHash("sha256").update(buffer).digest("hex");
 }
+
+export function decimalCount( numStr: string) {
+  // String Contains Decimal
+  if (numStr.includes('.')) {
+     return numStr.split('.')[1].length;
+  };
+  // String Does Not Contain Decimal
+  return 0;
+}


### PR DESCRIPTION
moved crucible cards into their own functional component to allow for each crucible to have its own internal state associated to it

Values with more than 3 decimals have tooltips on hover to signify to users that they can click it to expand to full number. Balance and locked balance cannot be expanded at the same time to fix possible overlap issues.


https://user-images.githubusercontent.com/34298590/111086862-914fb380-84ec-11eb-82d8-030ad4b3c478.mp4







