### PR TITLE
allow users to refresh their crucibles list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1296,6 +1296,27 @@
         "@chakra-ui/utils": "1.3.0"
       }
     },
+    "@chakra-ui/icons": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-1.0.6.tgz",
+      "integrity": "sha512-r2jZQ7DOGKWMOpWF2LXapn60brSSmenRwBC/1pj/vqWB8XQcgx74QB+ZsYsOUrRnlM83xpay9S6D8mv/m4cdzw==",
+      "requires": {
+        "@chakra-ui/icon": "1.1.2",
+        "@types/react": "^17.0.0"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "17.0.3",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+          "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        }
+      }
+    },
     "@chakra-ui/image": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.8.tgz",
@@ -3380,8 +3401,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -3429,8 +3449,7 @@
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/secp256k1": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@chakra-ui/icons": "^1.0.6",
     "@chakra-ui/react": "^1.3.4",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",

--- a/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
+++ b/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
@@ -239,29 +239,24 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
         <Spinner />
       ) : (
         <>
-          {isConnected && (
-            <>
-              {crucibles.length ? (
-                <>
-                  {crucibles.map((crucible) => {
-                    return (
-                      <CrucibleCard
-                        crucible={crucible}
-                        setModalOperation={setModalOperation}
-                        setModalIsOpen={setModalIsOpen}
-                        setSelectedCrucible={setSelectedCrucible}
-                      />
-                    );
-                  })}
-                </>
-              ) : (
-                <Text textAlign="left">
-                  Your crucibles may not be appearing if you are on a private network. Switch to the Mainnet and click
-                  the refresh button.
-                </Text>
-              )}
-            </>
-          )}
+          {isConnected &&
+            (crucibles.length ? (
+              crucibles.map((crucible) => {
+                return (
+                  <CrucibleCard
+                    crucible={crucible}
+                    setModalOperation={setModalOperation}
+                    setModalIsOpen={setModalIsOpen}
+                    setSelectedCrucible={setSelectedCrucible}
+                  />
+                );
+              })
+            ) : (
+              <Text textAlign="left">
+                Your crucibles may not be appearing if you are on a private network. Switch to the Mainnet and click the
+                refresh button.
+              </Text>
+            ))}
         </>
       )}
       {isConnected ? (

--- a/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
+++ b/src/views/Widget/TabContent/Panes/Operate/OperatePane.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useContext } from "react";
-import { toMaxDecimalsRound, decimalCount } from "../../../utils";
+import { toMaxDecimalsRound } from "../../../utils";
 import Web3Context from "../../../../../Web3Context";
 import { getOwnedCrucibles } from "../../../../../contracts/getOwnedCrucibles";
 import { unstakeAndClaim } from "../../../../../contracts/unstakeAndClaim";
 import { sendNFT } from "../../../../../contracts/sendNFT";
 import { withdraw } from "../../../../../contracts/withdraw";
-import { Button, ButtonGroup } from "@chakra-ui/button";
-import { Badge, Box, Flex, HStack, Text, Link } from "@chakra-ui/layout";
-import { FaLock } from "react-icons/fa";
+import { Button } from "@chakra-ui/button";
+import { Link, Flex } from "@chakra-ui/layout";
 import {
   Modal,
   ModalOverlay,
@@ -19,6 +18,8 @@ import {
 } from "@chakra-ui/modal";
 import { Input } from "@chakra-ui/input";
 import { FormControl, FormLabel } from "@chakra-ui/form-control";
+import { RepeatIcon } from "@chakra-ui/icons";
+import { Spinner, Text } from "@chakra-ui/react";
 import { mintAndLock } from "../../../../../contracts/alchemist";
 import CrucibleCard from "./CrucibleCard";
 
@@ -37,6 +38,7 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [modalOperation, setModalOperation] = useState<"withdraw" | "unstake" | "send" | "increaseStake">("unstake");
   const [selectedCrucible, setSelectedCrucible] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
   const [formValues, setFormValues] = useState({
     lnBalance: "",
@@ -95,7 +97,9 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
       return;
     }
     await unstakeAndClaim(signer, monitorTx, selectedCrucible, amount);
-    alert("Unstaked! Remember to change your network back to Mainnet to see your crucibles.");
+    alert(
+      "Unstaked! Remember to change your network back to Mainnet and hit the refresh button to see your crucibles."
+    );
     setModalIsOpen(false);
   };
   const increaseStake = async () => {
@@ -106,6 +110,14 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
   const withdrawTokens = async () => {
     await withdraw(selectedCrucible, amount);
     setModalIsOpen(false);
+  };
+
+  const reloadCrucibles = () => {
+    setIsLoading(true);
+    getOwnedCrucibles(signer, provider).then((cruciblesOnCurrentNetwork) => {
+      setCrucibles(cruciblesOnCurrentNetwork);
+      setIsLoading(false);
+    });
   };
 
   const sendModal = (
@@ -218,17 +230,40 @@ const OperatePane: React.FC<OperatePaneProps> = (props) => {
             </ModalContent>
           </Modal>
         ))}
-
-      {crucibles.map((crucible) => {
-        return (
-          <CrucibleCard
-            crucible={crucible}
-            setModalOperation={setModalOperation}
-            setModalIsOpen={setModalIsOpen}
-            setSelectedCrucible={setSelectedCrucible}
-          />
-        );
-      })}
+      {isConnected && (
+        <Flex flexDirection="column">
+          <RepeatIcon onClick={reloadCrucibles} _hover={{ cursor: "pointer" }} alignSelf="flex-end" mb={4} />
+        </Flex>
+      )}
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          {isConnected && (
+            <>
+              {crucibles.length ? (
+                <>
+                  {crucibles.map((crucible) => {
+                    return (
+                      <CrucibleCard
+                        crucible={crucible}
+                        setModalOperation={setModalOperation}
+                        setModalIsOpen={setModalIsOpen}
+                        setSelectedCrucible={setSelectedCrucible}
+                      />
+                    );
+                  })}
+                </>
+              ) : (
+                <Text textAlign="left">
+                  Your crucibles may not be appearing if you are on a private network. Switch to the Mainnet and click
+                  the refresh button.
+                </Text>
+              )}
+            </>
+          )}
+        </>
+      )}
       {isConnected ? (
         <></>
       ) : (


### PR DESCRIPTION
This allows users to switch networks and view their crucibles without having to refresh the whole page.

1. Give the ability to refresh the crucibles list. 
2. Displays message when wallet is connected and crucible list is empty that networks may need to be switched
3. update alert message after unstaking